### PR TITLE
Add blastdb folder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,8 @@ RUN mkdir -p /blastdb && \
     cd /blastdb && \
     update_blastdb.pl --decompress taxdb
 
+ENV BLASTDB=/blastdb
+
 COPY filter_catalog.py /
 COPY filter_nonplant_loci.py /
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,9 @@ RUN tar -xvf ncbi-blast-2.15.0+-x64-linux.tar.gz && \
     cd / && \
     rm -rf ncbi-blast-2.15.0+-x64-linux.tar.gz ncbi-blast-2.15.0+
 
-RUN update_blastdb.pl --decompress taxdb
+RUN mkdir -p /blastdb && \
+    cd /blastdb && \
+    update_blastdb.pl --decompress taxdb
 
 COPY filter_catalog.py /
 COPY filter_nonplant_loci.py /


### PR DESCRIPTION
Since blastn in the nextflow environment cannot find the taxdb files in root, create a blastdb folder to store the taxdb files in and set an environment variable to direct blastn to that folder